### PR TITLE
v1.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.6)
 
-set(VERSION "1.0.1")
+set(VERSION "1.0.2")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > Privacy Focused Decentralised Banking.
 
 ![status](https://img.shields.io/badge/Status-Mainnet-green)
-![version](https://img.shields.io/badge/Version-1.0.1-blue)
+![version](https://img.shields.io/badge/Version-1.0.2-blue)
 
 [![discord](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/discord-50px.png)](https://discord.gg/PHyGJjg)
 [![github](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/github-50px.png)](https://github.com/cache-core)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 ![status](https://img.shields.io/badge/Status-Mainnet-green)
 ![version](https://img.shields.io/badge/Version-1.0.1-blue)
 
+[![discord](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/discord-50px.png)](https://discord.gg/PHyGJjg)
+[![github](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/github-50px.png)](https://github.com/cache-core)
+[![reddit](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/reddit-50px.png)](https://reddit.com/r/cxche)
+[![telegram](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/telegram-50px.png)](https://t.me/cxche)
+[![twitter](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/twitter-50px.png)](https://twitter.com/cachecore)
+
 ***
 
 ### Docs & Guides
@@ -28,18 +34,24 @@
 
 ***
 
+### Software
+
+#### Core Clients
+
 | Branch | Status | Download |
 |-------|--------|----------|
-| `main` | [![Build status](https://ci.appveyor.com/api/projects/status/i25lltupg55v6uwq/branch/main?svg=true)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/branch/main) | [![Win x64](https://img.shields.io/badge/Win%20x64-Download-blue)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/build/artifacts) |
-| `development` | [![Build status](https://ci.appveyor.com/api/projects/status/i25lltupg55v6uwq/branch/development?svg=true)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/branch/main) | [![Win x64](https://img.shields.io/badge/Win%20x64-Download-blue)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/build/artifacts) |
+| `main` | [![Build status](https://ci.appveyor.com/api/projects/status/1ymndgoxcjs2h6xn/branch/main?svg=true)](https://ci.appveyor.com/project/En4orcer/cache/branch/main) | [![Win x64](https://img.shields.io/badge/Win%20x64-Download-blue)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/build/artifacts) |
+| `development` | [![Build status](https://ci.appveyor.com/api/projects/status/1ymndgoxcjs2h6xn/branch/development?svg=true)](https://ci.appveyor.com/project/En4orcer/cache/branch/development) | [![Win x64](https://img.shields.io/badge/Win%20x64-Download-blue)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/build/artifacts) |
+
+#### Desktop Wallet
+
+| Build | Status | Download |
+|-------|--------|----------|
+| `master` | [![Build status](https://ci.appveyor.com/api/projects/status/gusvs4l2vd7lgth2/branch/master?svg=true)](https://ci.appveyor.com/project/En4orcer/cache-desktop/branch/master) | [![Win x64](https://img.shields.io/badge/Win%20x64-Download-blue)](https://ci.appveyor.com/project/En4orcer/project/build/artifacts) |
+| `development` | [![Build status](https://ci.appveyor.com/api/projects/status/gusvs4l2vd7lgth2/branch/development?svg=true)](https://ci.appveyor.com/project/En4orcer/cache-desktop/branch/development) | [![Win x64](https://img.shields.io/badge/Win%20x64-Download-blue)](https://ci.appveyor.com/project/En4orcer/cache-7su1f/build/artifacts) |
 
 ***
 
-### Social
-> Follow every step we take.
+### Supporting Partners
 
-[![discord](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/discord-50px.png)](https://discord.gg/PHyGJjg)
-[![github](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/github-50px.png)](https://github.com/cache-core)
-[![reddit](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/reddit-50px.png)](https://reddit.com/r/cxche)
-[![telegram](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/telegram-50px.png)](https://t.me/cxche)
-[![twitter](https://github.com/project-en4orcer/Assets/blob/master/social-icons/bubble/twitter-50px.png)](https://twitter.com/cachecore)
+[![LetsHash](https://github.com/letshash/letshash.it/blob/master/assets/img/favicon-96x96.png?raw=true)](https://letshash.it/#/)

--- a/include/ITransfersContainer.h
+++ b/include/ITransfersContainer.h
@@ -34,6 +34,7 @@ namespace CryptoNote
     std::vector<uint8_t> extra;
     Crypto::Hash paymentId;
     std::vector<std::string> messages;
+    Crypto::SecretKey secretKey;
   };
 
   struct TransactionOutputInformation

--- a/include/ITransfersContainer.h
+++ b/include/ITransfersContainer.h
@@ -34,7 +34,6 @@ namespace CryptoNote
     std::vector<uint8_t> extra;
     Crypto::Hash paymentId;
     std::vector<std::string> messages;
-    Crypto::SecretKey secretKey;
   };
 
   struct TransactionOutputInformation

--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -94,7 +94,7 @@ struct WalletTransaction
   uint64_t timestamp;
   uint32_t blockHeight;
   Crypto::Hash hash;
-  Crypto::SecretKey secretKey;
+  boost::optional<Crypto::SecretKey> secretKey;
   int64_t totalAmount;
   uint64_t fee;
   uint64_t creationTime;
@@ -217,6 +217,7 @@ public:
 
   virtual size_t getTransactionCount() const = 0;
   virtual WalletTransaction getTransaction(size_t transactionIndex) const = 0;
+  virtual Crypto::SecretKey getTransactionSecretKey(size_t transactionIndex) const = 0;
   virtual size_t getTransactionTransferCount(size_t transactionIndex) const = 0;
   virtual WalletTransfer getTransactionTransfer(size_t transactionIndex, size_t transferIndex) const = 0;
 

--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -94,7 +94,7 @@ struct WalletTransaction
   uint64_t timestamp;
   uint32_t blockHeight;
   Crypto::Hash hash;
-  boost::optional<Crypto::SecretKey> secretKey;
+  Crypto::SecretKey secretKey;
   int64_t totalAmount;
   uint64_t fee;
   uint64_t creationTime;

--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -62,7 +62,7 @@ struct WalletLegacyTransaction {
   uint64_t         sentTime;
   uint64_t         unlockTime;
   Crypto::Hash     hash;
-  boost::optional<Crypto::SecretKey> secretKey = CryptoNote::NULL_SECRET_KEY;
+  Crypto::SecretKey secretKey;
 
   bool             isCoinbase;
   uint32_t         blockHeight;
@@ -152,6 +152,7 @@ public:
   virtual TransactionId deposit(uint64_t term, uint64_t amount, uint64_t fee, uint64_t mixIn = 0) = 0;
   virtual TransactionId withdrawDeposits(const std::vector<DepositId>& depositIds, uint64_t fee) = 0;
   virtual std::error_code cancelTransaction(size_t transferId) = 0;
+  virtual bool checkTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, std::string& sig_str) = 0;
 
 };
 

--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -16,6 +16,7 @@
 #include <vector>
 #include <list>
 #include <boost/optional.hpp>
+#include "crypto/crypto.h"
 #include "CryptoNote.h"
 #include "CryptoNoteCore/CryptoNoteBasic.h"
 #include "Rpc/CoreRpcServerCommandsDefinitions.h"
@@ -62,7 +63,7 @@ struct WalletLegacyTransaction {
   uint64_t         sentTime;
   uint64_t         unlockTime;
   Crypto::Hash     hash;
-  Crypto::SecretKey secretKey;
+  boost::optional<Crypto::SecretKey> secretKey = CryptoNote::NULL_SECRET_KEY;
 
   bool             isCoinbase;
   uint32_t         blockHeight;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1127,4 +1127,19 @@ bool core::removeMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) {
   return m_blockchain.removeMessageQueue(messageQueue);
 }
 
+std::vector<Crypto::Hash> core::getTransactionHashesByPaymentId(const Crypto::Hash& paymentId) {
+  logger(DEBUGGING) << "getTransactionHashesByPaymentId request with paymentId " << paymentId;
+
+  std::vector<Crypto::Hash> blockchainTransactionHashes;
+  m_blockchain.getTransactionIdsByPaymentId(paymentId, blockchainTransactionHashes);
+
+  std::vector<Crypto::Hash> poolTransactionHashes;
+  m_mempool.getTransactionIdsByPaymentId(paymentId, poolTransactionHashes);
+
+  blockchainTransactionHashes.reserve(blockchainTransactionHashes.size() + poolTransactionHashes.size());
+  std::move(poolTransactionHashes.begin(), poolTransactionHashes.end(), std::back_inserter(blockchainTransactionHashes));
+
+  return blockchainTransactionHashes;
+}
+
 }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -81,6 +81,7 @@ core(const Currency& currency, i_cryptonote_protocol* pprotocol, Logging::ILogge
      virtual bool check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_context& tvc);// override;
      virtual bool handleIncomingTransaction(const Transaction& tx, const Crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, bool keptByBlock, uint32_t height) override;
      virtual std::error_code executeLocked(const std::function<std::error_code()>& func) override;
+     virtual std::vector<Crypto::Hash> getTransactionHashesByPaymentId(const Crypto::Hash& paymentId) override;
      
      virtual bool addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;
      virtual bool removeMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -101,6 +101,7 @@ public:
   virtual bool getBlocksByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<Block>& blocks, uint32_t& blocksNumberWithinTimestamps) = 0;
   virtual bool getPoolTransactionsByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<Transaction>& transactions, uint64_t& transactionsNumberWithinTimestamps) = 0;
   virtual bool getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<Transaction>& transactions) = 0;
+  virtual std::vector<Crypto::Hash> getTransactionHashesByPaymentId(const Crypto::Hash& paymentId) = 0;
 
   virtual std::unique_ptr<IBlock> getBlock(const Crypto::Hash& blocksId) = 0;
   virtual bool handleIncomingTransaction(const Transaction& tx, const Crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, bool keptByBlock, uint32_t height) = 0;

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -693,4 +693,18 @@ std::error_code NodeRpcProxy::jsonRpcCommand(const std::string& method, const Re
   return ec;
 }
 
+std::error_code NodeRpcProxy::doGetTransactionHashesByPaymentId(const Crypto::Hash& paymentId, std::vector<Crypto::Hash>& transactionHashes) {
+  COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response resp = AUTO_VAL_INIT(resp);
+
+  req.paymentId = paymentId;
+  std::error_code ec = jsonCommand("/get_transaction_hashes_by_payment_id", req, resp);
+  if (ec) {
+    return ec;
+  }
+
+  transactionHashes = std::move(resp.transactionHashes);
+  return ec;
+}
+
 }

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -68,6 +68,7 @@ public:
   virtual void getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void getPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps, const Callback& callback) override;
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
+  std::error_code doGetTransactionHashesByPaymentId(const Crypto::Hash& paymentId, std::vector<Crypto::Hash>& transactionHashes);
 
   unsigned int rpcTimeout() const { return m_rpcTimeout; }
   void rpcTimeout(unsigned int val) { m_rpcTimeout = val; }

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -15,7 +15,7 @@
 namespace PaymentService
 {
 
-const uint32_t DEFAULT_ANONYMITY_LEVEL = 4;
+const uint32_t DEFAULT_ANONYMITY_LEVEL = 0;
 
 class RequestSerializationError : public std::exception
 {

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -99,6 +99,7 @@ namespace PaymentService
       Crypto::Hash paymentId;
       bool r = Common::podFromHex(paymentIdStr, paymentId);
       assert(r);
+      if (!r) {}
 
       return paymentId;
     }
@@ -1097,7 +1098,6 @@ namespace PaymentService
         spendingTransactionHash = Common::podToHex(walletstx.hash);
       }
 
-      bool state = true;
       uint32_t knownBlockCount = node.getKnownBlockCount();
       if (knownBlockCount > unlockHeight)
       {
@@ -1406,6 +1406,9 @@ namespace PaymentService
     const bool valid = CryptoNote::parseAccountAddressString(prefix,
                                                              addr,
                                                              address_str);
+    if (!valid) {
+      logger(Logging::ERROR) << "Couldn't parse the address string!";
+    }
 
     CryptoNote::BinaryArray ba;
     CryptoNote::toBinaryArray(addr, ba);
@@ -1602,8 +1605,6 @@ namespace PaymentService
     try
     {
       System::EventLock lk(readyEvent);
-
-      auto estimateResult = fusionManager.estimate(1000000, {});
       knownBlockCount = node.getKnownBlockCount();
       peerCount = static_cast<uint32_t>(node.getPeerCount());
       blockCount = wallet.getBlockCount();

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -882,4 +882,24 @@ struct COMMAND_RPC_GET_FEE_ADDRESS {
   };
 };
 
+struct COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID {
+  struct request {
+    Crypto::Hash paymentId;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(paymentId)
+    }
+  };
+
+  struct response {
+    std::vector<Crypto::Hash> transactionHashes;
+    std::string status;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(status)
+      KV_MEMBER(transactionHashes);
+    }
+  };
+};
+
 }

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -810,6 +810,37 @@ struct reserve_proof {
 	}
 };
 
+struct COMMAND_RPC_CHECK_TX_KEY
+{
+  struct request
+  {
+    std::string txid;
+    std::string txkey;
+    std::string address;
+
+    void serialize(ISerializer &s)
+    {
+      KV_MEMBER(txid)
+      KV_MEMBER(txkey)
+      KV_MEMBER(address)
+    }
+  };
+
+  struct response
+  {
+    uint64_t amount;
+    std::vector<TransactionOutput> outputs;
+    std::string status;
+
+    void serialize(ISerializer &s)
+    {
+      KV_MEMBER(amount)
+      KV_MEMBER(outputs)
+      KV_MEMBER(status)
+    }
+  };
+};
+
 struct K_COMMAND_RPC_CHECK_TX_PROOF {
     struct request {
         std::string tx_id;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -96,6 +96,7 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   { "/feeinfo", { jsonMethod<COMMAND_RPC_GET_FEE_ADDRESS>(&RpcServer::on_get_fee_info), true } }, 
   { "/peers", { jsonMethod<COMMAND_RPC_GET_PEER_LIST>(&RpcServer::on_get_peer_list), true } },
   { "/getpeers", { jsonMethod<COMMAND_RPC_GET_PEER_LIST>(&RpcServer::on_get_peer_list), true } },
+  { "/get_transaction_hashes_by_payment_id", { jsonMethod<COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID>(&RpcServer::on_get_transaction_hashes_by_paymentid), true } },
 
   // json rpc
   { "/json_rpc", { std::bind(&RpcServer::processJsonRpcRequest, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), true } }
@@ -150,6 +151,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
       { "getcurrencyid", { makeMemberMethod(&RpcServer::on_get_currency_id), true } },
       { "submitblock", { makeMemberMethod(&RpcServer::on_submitblock), false } },
       { "getlastblockheader", { makeMemberMethod(&RpcServer::on_get_last_block_header), false } },
+      { "gettransactionhashesbypaymentid", { makeMemberMethod(&RpcServer::on_get_transaction_hashes_by_paymentid), true } },
       { "getblockheaderbyhash", { makeMemberMethod(&RpcServer::on_get_block_header_by_hash), false } },
       { "getblockheaderbyheight", { makeMemberMethod(&RpcServer::on_get_block_header_by_height), false } }
     };
@@ -586,6 +588,13 @@ bool RpcServer::onGetPoolChangesLite(const COMMAND_RPC_GET_POOL_CHANGES_LITE::re
 
 bool RpcServer::setNodeInfo(const std::string& nodeInfo) {
   m_node_info = nodeInfo;
+  return true;
+}
+
+bool RpcServer::on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response& rsp) {
+  rsp.transactionHashes = m_core.getTransactionHashesByPaymentId(req.paymentId);
+
+  rsp.status = CORE_RPC_STATUS_OK;
   return true;
 }
 

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -70,6 +70,7 @@ private:
   bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
   bool on_get_fee_info(const COMMAND_RPC_GET_FEE_ADDRESS::request& req, COMMAND_RPC_GET_FEE_ADDRESS::response& res);
   bool on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response& rsp);
+  bool on_check_tx_key(const COMMAND_RPC_CHECK_TX_KEY::request& req, COMMAND_RPC_CHECK_TX_KEY::response& res);
 
   // json rpc
   bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -69,6 +69,7 @@ private:
   bool on_stop_mining(const COMMAND_RPC_STOP_MINING::request& req, COMMAND_RPC_STOP_MINING::response& res);
   bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
   bool on_get_fee_info(const COMMAND_RPC_GET_FEE_ADDRESS::request& req, COMMAND_RPC_GET_FEE_ADDRESS::response& res);
+  bool on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response& rsp);
 
   // json rpc
   bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1423,7 +1423,7 @@ bool simple_wallet::optimize_outputs(const std::vector<std::string>& args) {
     CryptoNote::WalletLegacyTransaction txInfo;
     m_wallet->getTransaction(tx, txInfo);
     success_msg_writer(true) << "Money successfully sent:\n\tTransaction ID: " << Common::podToHex(txInfo.hash);
-    success_msg_writer(true) << "\n\tTransaction Secret Key: " << Common::podToHex(transactionSK);
+    success_msg_writer(true) << "\tTransaction Secret Key: " << Common::podToHex(transactionSK);
 
     try {
       CryptoNote::WalletHelper::storeWallet(*m_wallet, m_wallet_file);

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -89,6 +89,7 @@ namespace CryptoNote
     bool show_num_unlocked_outputs(const std::vector<std::string> &args);
     bool optimize_outputs(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);
+    bool check_tx_proof(const std::vector<std::string> &args);
 	  bool get_reserve_proof(const std::vector<std::string> &args);    
     bool get_tx_proof(const std::vector<std::string> &args);    
     bool optimize_all_outputs(const std::vector<std::string> &args);

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -88,6 +88,7 @@ namespace CryptoNote
     bool show_blockchain_height(const std::vector<std::string> &args);
     bool show_num_unlocked_outputs(const std::vector<std::string> &args);
     bool optimize_outputs(const std::vector<std::string> &args);
+    bool get_tx_key(const std::vector<std::string> &args);
 	  bool get_reserve_proof(const std::vector<std::string> &args);    
     bool get_tx_proof(const std::vector<std::string> &args);    
     bool optimize_all_outputs(const std::vector<std::string> &args);

--- a/src/Wallet/PoolRpcServer.cpp
+++ b/src/Wallet/PoolRpcServer.cpp
@@ -342,6 +342,8 @@ bool pool_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREATE_
     const bool valid = CryptoNote::parseAccountAddressString(prefix, 
                                                             addr,
                                                             address_str);
+    if (!valid)
+        logger(Logging::ERROR) << "Couldn't parse the address string!";
 
     CryptoNote::BinaryArray ba;
     CryptoNote::toBinaryArray(addr, ba);

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -2668,6 +2668,15 @@ namespace CryptoNote
       tx->signInputKey(i++, input.keyInfo, input.ephKeys);
     }
 
+    SecretKey txkey;
+    tx->getTransactionSecretKey(txkey);
+    
+    m_logger(Logging::DEBUGGING) << "Transaction created, hash " << Common::podToHex(tx->getTransactionHash()) <<
+      ", inputs " << m_currency.formatAmount(tx->getInputTotalAmount()) <<
+      ", outputs " << m_currency.formatAmount(tx->getOutputTotalAmount()) <<
+      ", fee " << m_currency.formatAmount(tx->getInputTotalAmount() - tx->getOutputTotalAmount()) <<
+      ", key " << Common::podToHex(txkey);
+
     return tx;
   }
 
@@ -3144,6 +3153,21 @@ namespace CryptoNote
 
     return result;
   }
+
+  Crypto::SecretKey WalletGreen::getTransactionSecretKey(size_t transactionIndex) const
+  {
+    throwIfNotInitialized();
+    throwIfStopped();
+
+    if (m_transactions.size() <= transactionIndex)
+    {
+      m_logger(ERROR, BRIGHT_RED) << "Failed to get transaction: invalid index " << transactionIndex << ". Number of transactions: " << m_transactions.size();
+      throw std::system_error(make_error_code(CryptoNote::error::INDEX_OUT_OF_RANGE));
+    }
+
+    return m_transactions.get<RandomAccessIndex>()[transactionIndex].secretKey.get();
+  }
+
 
   void WalletGreen::start()
   {

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -83,6 +83,7 @@ public:
   virtual WalletTransfer getTransactionTransfer(size_t transactionIndex, size_t transferIndex) const override;
 
   virtual WalletTransactionWithTransfers getTransaction(const Crypto::Hash &transactionHash) const override;
+  virtual Crypto::SecretKey getTransactionSecretKey(size_t transactionIndex) const override;
 
   virtual std::vector<TransactionsInBlockInfo> getTransactions(const Crypto::Hash &blockHash, size_t count) const;
   virtual std::vector<TransactionsInBlockInfo> getTransactions(uint32_t blockIndex, size_t count) const;

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -57,6 +57,7 @@ namespace Tools
     bool on_get_messages(const wallet_rpc::COMMAND_RPC_GET_MESSAGES::request& req, wallet_rpc::COMMAND_RPC_GET_MESSAGES::response& res);
     bool on_get_payments(const wallet_rpc::COMMAND_RPC_GET_PAYMENTS::request& req, wallet_rpc::COMMAND_RPC_GET_PAYMENTS::response& res);
     bool on_get_transfers(const wallet_rpc::COMMAND_RPC_GET_TRANSFERS::request& req, wallet_rpc::COMMAND_RPC_GET_TRANSFERS::response& res);
+    bool on_get_tx_key(const wallet_rpc::COMMAND_RPC_GET_TX_KEY::request& req, wallet_rpc::COMMAND_RPC_GET_TX_KEY::response& res);
 	  bool on_get_tx_proof(const wallet_rpc::COMMAND_RPC_GET_TX_PROOF::request& req, wallet_rpc::COMMAND_RPC_GET_TX_PROOF::response& res);
 	  bool on_get_reserve_proof(const wallet_rpc::COMMAND_RPC_GET_BALANCE_PROOF::request& req, wallet_rpc::COMMAND_RPC_GET_BALANCE_PROOF::response& res);    
     bool on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::request& req, wallet_rpc::COMMAND_RPC_GET_HEIGHT::response& res);

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -386,5 +386,29 @@ using CryptoNote::ISerializer;
       }
     };
   };
+  
+	/* Command: get_tx_key */
+  struct COMMAND_RPC_GET_TX_KEY
+  {
+    struct request
+    {
+      std::string tx_hash;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(tx_hash)
+      }
+    };
+
+    struct response
+    {
+      std::string tx_key;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(tx_key)
+      }
+    };
+  };
 }
 }

--- a/src/Wallet/WalletSerializationV2.cpp
+++ b/src/Wallet/WalletSerializationV2.cpp
@@ -51,6 +51,8 @@ struct WalletTransactionDtoV2 {
     unlockTime = wallet.unlockTime;
     extra = wallet.extra;
     isBase = wallet.isBase;
+    if (wallet.secretKey)
+      secretKey = reinterpret_cast<const Crypto::SecretKey&>(wallet.secretKey.get());
   }
 
   CryptoNote::WalletTransactionState state;
@@ -65,6 +67,7 @@ struct WalletTransactionDtoV2 {
   uint64_t unlockTime;
   std::string extra;
   bool isBase;
+  boost::optional<Crypto::SecretKey> secretKey;
 };
 
 //DO NOT CHANGE IT
@@ -139,6 +142,8 @@ void serialize(WalletTransactionDtoV2& value, CryptoNote::ISerializer& serialize
   serializer(value.unlockTime, "unlockTime");
   serializer(value.extra, "extra");
   serializer(value.isBase, "isBase");
+  if (value.secretKey)
+    serializer(value.secretKey.get(), "secret_key");
 }
 
 void serialize(WalletTransferDtoV2& value, CryptoNote::ISerializer& serializer) {
@@ -348,6 +353,8 @@ void WalletSerializerV2::loadTransactions(CryptoNote::ISerializer& serializer) {
     tx.unlockTime = dto.unlockTime;
     tx.extra = dto.extra;
     tx.isBase = dto.isBase;
+    if (dto.secretKey)
+      tx.secretKey = reinterpret_cast<const Crypto::SecretKey&>(dto.secretKey.get());
 
     m_transactions.get<RandomAccessIndex>().emplace_back(std::move(tx));
   }

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -1223,7 +1223,7 @@ bool WalletLegacy::get_tx_key(Crypto::Hash& txid, Crypto::SecretKey& txSecretKey
   TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
   WalletLegacyTransaction transaction;
   getTransaction(ti, transaction);
-  txSecretKey = transaction.secretKey;//.get();
+  txSecretKey = transaction.secretKey.get();
   if (txSecretKey == NULL_SECRET_KEY) {
     return false;
   }
@@ -1236,7 +1236,11 @@ Crypto::SecretKey WalletLegacy::getTxKey(Crypto::Hash& txid)
   TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
   WalletLegacyTransaction transaction;
   getTransaction(ti, transaction);
-  return transaction.secretKey;
+  if (transaction.secretKey) {
+     return reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
+  } else {
+     return NULL_SECRET_KEY;
+  }
 }
 
 bool WalletLegacy::checkTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, std::string& sig_str) {

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -1149,6 +1149,7 @@ std::vector<uint32_t> WalletLegacy::getTransactionHeights(const std::vector<Tran
 	  TransactionInformation info;
 	  bool ok = m_transferDetails->getTransactionInformation(hash, info, NULL, NULL);
 	  assert(ok);
+    if (!ok) {}
 	  heights.push_back(info.blockHeight);
   }
   return heights;
@@ -1218,26 +1219,73 @@ void WalletLegacy::pushBalanceUpdatedEvents(std::deque<std::unique_ptr<WalletLeg
   }
 }
 
-Crypto::SecretKey WalletLegacy::getTxKey(Crypto::Hash& txid) {
-  TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
-  WalletLegacyTransaction transaction;
-  getTransaction(ti, transaction);
-  if (transaction.secretKey) {
-     return reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
-  } else {
-     return NULL_SECRET_KEY;
-  }
-}
 bool WalletLegacy::get_tx_key(Crypto::Hash& txid, Crypto::SecretKey& txSecretKey) {
   TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
   WalletLegacyTransaction transaction;
   getTransaction(ti, transaction);
-  txSecretKey = transaction.secretKey.get();
+  txSecretKey = transaction.secretKey;//.get();
   if (txSecretKey == NULL_SECRET_KEY) {
     return false;
   }
 
   return true;
+}
+
+Crypto::SecretKey WalletLegacy::getTxKey(Crypto::Hash& txid)
+{
+  TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
+  WalletLegacyTransaction transaction;
+  getTransaction(ti, transaction);
+  return transaction.secretKey;
+}
+
+bool WalletLegacy::checkTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, std::string& sig_str) {
+  const size_t header_len = strlen("ProofV1");
+  if (sig_str.size() < header_len || sig_str.substr(0, header_len) != "ProofV1")
+  {
+	std::cout << "Signature header check error";
+    return false;
+  }
+  Crypto::PublicKey rA;
+  Crypto::Signature sig;
+  const size_t rA_len = Tools::Base58::encode(std::string((const char *)&rA, sizeof(Crypto::PublicKey))).size();
+  const size_t sig_len = Tools::Base58::encode(std::string((const char *)&sig, sizeof(Crypto::Signature))).size();
+  std::string rA_decoded;
+  std::string sig_decoded;
+  if (!Tools::Base58::decode(sig_str.substr(header_len, rA_len), rA_decoded)) {
+    std::cout << "Signature decoding error";
+	return false;
+  }
+  if (!Tools::Base58::decode(sig_str.substr(header_len + rA_len, sig_len), sig_decoded))
+  {
+    std::cout << "Signature decoding error";
+    return false;
+  }
+  if (sizeof(Crypto::PublicKey) != rA_decoded.size() || sizeof(Crypto::Signature) != sig_decoded.size())
+  {
+    std::cout << "Signature decoding error";
+    return false;
+  }
+  memcpy(&rA, rA_decoded.data(), sizeof(Crypto::PublicKey));
+  memcpy(&sig, sig_decoded.data(), sizeof(Crypto::PublicKey));
+
+  // fetch tx pubkey
+  TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
+  WalletLegacyTransaction tx;
+  if (!getTransaction(ti, tx)) {
+    std::cout << "Transaction with hash " << Common::podToHex(txid) << "is not found";
+	return false;
+  }
+  CryptoNote::TransactionPrefix txp = *reinterpret_cast<const TransactionPrefix*>(&tx);
+  Crypto::PublicKey R = getTransactionPublicKeyFromExtra(txp.extra);
+  if (R == NULL_PUBLIC_KEY)
+  {
+    std::cout << "Tx pubkey was not found";
+    return false;
+  }
+
+  // check signature
+  return Crypto::check_tx_proof(txid, R, address.viewPublicKey, rA, sig);
 }
 
 bool WalletLegacy::getTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, Crypto::SecretKey& tx_key, std::string& sig_str) {

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -73,6 +73,7 @@ public:
   virtual bool isTrackingWallet();
   virtual TransactionId findTransactionByTransferId(TransferId transferId) override;
   virtual bool getTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, Crypto::SecretKey& tx_key, std::string& sig_str) override;
+  virtual bool checkTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, std::string& sig_str) override;
   virtual std::string getReserveProof(const uint64_t &reserve, const std::string &message) override;
   virtual Crypto::SecretKey getTxKey(Crypto::Hash& txid) override;
   virtual bool get_tx_key(Crypto::Hash& txid, Crypto::SecretKey& txSecretKey) override;
@@ -85,7 +86,7 @@ public:
                                         const WalletLegacyTransfer& transfer,
                                         uint64_t fee,
                                         const std::string& extra = "",
-                                        uint64_t mixIn = 4,
+                                        uint64_t mixIn = 0,
                                         uint64_t unlockTimestamp = 0,
                                         const std::vector<TransactionMessage>& messages = std::vector<TransactionMessage>(),
                                         uint64_t ttl = 0) override;
@@ -93,14 +94,14 @@ public:
                                         std::vector<WalletLegacyTransfer>& transfers,
                                         uint64_t fee,
                                         const std::string& extra = "",
-                                        uint64_t mixIn = 4,
+                                        uint64_t mixIn = 0,
                                         uint64_t unlockTimestamp = 0,
                                         const std::vector<TransactionMessage>& messages = std::vector<TransactionMessage>(),
                                         uint64_t ttl = 0) override;
   virtual size_t estimateFusion(const uint64_t& threshold);
   virtual std::list<TransactionOutputInformation> selectFusionTransfersToSend(uint64_t threshold, size_t minInputCount, size_t maxInputCount);
   virtual TransactionId sendFusionTransaction(const std::list<TransactionOutputInformation>& fusionInputs, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0);
-  virtual TransactionId deposit(uint64_t term, uint64_t amount, uint64_t fee, uint64_t mixIn = 4) override;
+  virtual TransactionId deposit(uint64_t term, uint64_t amount, uint64_t fee, uint64_t mixIn = 0) override;
   virtual TransactionId withdrawDeposits(const std::vector<DepositId>& depositIds, uint64_t fee) override;
   virtual std::error_code cancelTransaction(size_t transactionId) override;
 

--- a/src/WalletLegacy/WalletLegacySerialization.cpp
+++ b/src/WalletLegacy/WalletLegacySerialization.cpp
@@ -8,6 +8,7 @@
 
 #include "WalletLegacy/WalletDepositInfo.h"
 #include "WalletLegacy/WalletUnconfirmedTransactions.h"
+#include "WalletLegacy/WalletLegacySerializer.h"
 #include "IWalletLegacy.h"
 
 #include "CryptoNoteCore/CryptoNoteSerialization.h"
@@ -26,6 +27,8 @@ void serialize(UnconfirmedTransferDetails& utd, CryptoNote::ISerializer& seriali
   uint64_t txId = static_cast<uint64_t>(utd.transactionId);
   serializer(txId, "transaction_id");
   utd.transactionId = static_cast<size_t>(txId);
+  Crypto::SecretKey secretKey = static_cast<Crypto::SecretKey>(utd.secretKey);
+  serializer(secretKey, "secret_key");
 }
 
 void serialize(UnconfirmedSpentDepositDetails& details, ISerializer& serializer) {
@@ -65,6 +68,7 @@ void serialize(WalletLegacyTransaction& txi, CryptoNote::ISerializer& serializer
   serializer(txi.timestamp, "timestamp");
   serializer(txi.unlockTime, "unlock_time");
   serializer(txi.extra, "extra");
+  serializer(txi.secretKey, "secret_key");
 
   uint8_t state = static_cast<uint8_t>(txi.state);
   serializer(state, "state");

--- a/src/WalletLegacy/WalletLegacySerialization.cpp
+++ b/src/WalletLegacy/WalletLegacySerialization.cpp
@@ -68,7 +68,9 @@ void serialize(WalletLegacyTransaction& txi, CryptoNote::ISerializer& serializer
   serializer(txi.timestamp, "timestamp");
   serializer(txi.unlockTime, "unlock_time");
   serializer(txi.extra, "extra");
-  serializer(txi.secretKey, "secret_key");
+  Crypto::SecretKey secretKey = reinterpret_cast<const Crypto::SecretKey&>(txi.secretKey.get());
+  serializer(secretKey, "secret_key");
+  txi.secretKey = secretKey;
 
   uint8_t state = static_cast<uint8_t>(txi.state);
   serializer(state, "state");

--- a/src/WalletLegacy/WalletSendTransactionContext.h
+++ b/src/WalletLegacy/WalletSendTransactionContext.h
@@ -36,6 +36,7 @@ struct SendTransactionContext
   std::vector<tx_message_entry> messages;
   uint64_t ttl;
   uint32_t depositTerm;
+  Crypto::SecretKey tx_key = NULL_SECRET_KEY;
 };
 
 } //namespace CryptoNote

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -441,7 +441,7 @@ namespace CryptoNote
       getObjectHash(tx, transaction.hash);
       transaction.secretKey = transactionSK;
 
-      m_transactionsCache.updateTransaction(context->transactionId, tx, totalAmount, context->selectedTransfers, transaction.secretKey);
+      m_transactionsCache.updateTransaction(context->transactionId, tx, totalAmount, context->selectedTransfers, context->tx_key);
 
       notifyBalanceChanged(events);
 
@@ -519,7 +519,7 @@ namespace CryptoNote
       transactionInfo.depositCount = 1;
 
       Transaction lowlevelTransaction = convertTransaction(*transaction, static_cast<size_t>(m_upperTransactionSizeLimit));
-      m_transactionsCache.updateTransaction(context->transactionId, lowlevelTransaction, totalAmount, context->selectedTransfers, transactionInfo.secretKey);
+      m_transactionsCache.updateTransaction(context->transactionId, lowlevelTransaction, totalAmount, context->selectedTransfers, context->tx_key);
       m_transactionsCache.addCreatedDeposit(depositId, deposit.amount + deposit.interest);
 
       notifyBalanceChanged(events);

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -441,7 +441,7 @@ namespace CryptoNote
       getObjectHash(tx, transaction.hash);
       transaction.secretKey = transactionSK;
 
-      m_transactionsCache.updateTransaction(context->transactionId, tx, totalAmount, context->selectedTransfers);
+      m_transactionsCache.updateTransaction(context->transactionId, tx, totalAmount, context->selectedTransfers, transaction.secretKey);
 
       notifyBalanceChanged(events);
 
@@ -512,7 +512,6 @@ namespace CryptoNote
       deposit.term = context->depositTerm;
       deposit.creatingTransactionId = context->transactionId;
       deposit.spendingTransactionId = WALLET_LEGACY_INVALID_TRANSACTION_ID;
-      uint32_t height = transactionInfo.blockHeight;
       deposit.interest = m_currency.calculateInterest(deposit.amount, deposit.term);
       deposit.locked = true;
       DepositId depositId = m_transactionsCache.insertDeposit(deposit, depositIndex, transaction->getTransactionHash());
@@ -520,7 +519,7 @@ namespace CryptoNote
       transactionInfo.depositCount = 1;
 
       Transaction lowlevelTransaction = convertTransaction(*transaction, static_cast<size_t>(m_upperTransactionSizeLimit));
-      m_transactionsCache.updateTransaction(context->transactionId, lowlevelTransaction, totalAmount, context->selectedTransfers);
+      m_transactionsCache.updateTransaction(context->transactionId, lowlevelTransaction, totalAmount, context->selectedTransfers, transactionInfo.secretKey);
       m_transactionsCache.addCreatedDeposit(depositId, deposit.amount + deposit.interest);
 
       notifyBalanceChanged(events);
@@ -917,6 +916,7 @@ namespace CryptoNote
       Deposit deposit;
       bool r = m_transactionsCache.getDeposit(id, deposit);
       assert(r);
+      if (r) {}
 
       foundMoney += deposit.amount + deposit.interest;
     }

--- a/src/WalletLegacy/WalletUnconfirmedTransactions.cpp
+++ b/src/WalletLegacy/WalletUnconfirmedTransactions.cpp
@@ -98,7 +98,7 @@ bool WalletUnconfirmedTransactions::eraseDepositSpendingTransaction(const Crypto
 }
 
 void WalletUnconfirmedTransactions::add(const Transaction& tx, TransactionId transactionId, 
-  uint64_t amount, const std::vector<TransactionOutputInformation>& usedOutputs) {
+  uint64_t amount, const std::vector<TransactionOutputInformation>& usedOutputs, Crypto::SecretKey& tx_key) {
 
   UnconfirmedTransferDetails& utd = m_unconfirmedTxs[getObjectHash(tx)];
 
@@ -106,6 +106,7 @@ void WalletUnconfirmedTransactions::add(const Transaction& tx, TransactionId tra
   utd.sentTime = time(nullptr);
   utd.tx = tx;
   utd.transactionId = transactionId;
+  utd.secretKey = tx_key;
 
   uint64_t outsAmount = 0;
   // process used outputs

--- a/src/WalletLegacy/WalletUnconfirmedTransactions.h
+++ b/src/WalletLegacy/WalletUnconfirmedTransactions.h
@@ -49,6 +49,7 @@ struct UnconfirmedTransferDetails {
   time_t sentTime;
   TransactionId transactionId;
   std::vector<TransactionOutputId> usedOutputs;
+  Crypto::SecretKey secretKey;
 };
 
 struct UnconfirmedSpentDepositDetails {
@@ -69,7 +70,7 @@ public:
   bool findTransactionId(const Crypto::Hash& hash, TransactionId& id);
   void erase(const Crypto::Hash& hash);
   void add(const CryptoNote::Transaction& tx, TransactionId transactionId, 
-    uint64_t amount, const std::vector<TransactionOutputInformation>& usedOutputs);
+    uint64_t amount, const std::vector<TransactionOutputInformation>& usedOutputs, Crypto::SecretKey& tx_key);
   void updateTransactionId(const Crypto::Hash& hash, TransactionId id);
 
   void addCreatedDeposit(DepositId id, uint64_t totalAmount);

--- a/src/WalletLegacy/WalletUserTransactionsCache.cpp
+++ b/src/WalletLegacy/WalletUserTransactionsCache.cpp
@@ -305,7 +305,7 @@ std::deque<std::unique_ptr<WalletLegacyEvent>> WalletUserTransactionsCache::onTr
     transaction.state = WalletLegacyTransactionState::Active;
     transaction.unlockTime = txInfo.unlockTime;
     transaction.messages = txInfo.messages;
-    transaction.secretKey = txInfo.secretKey;
+    transaction.secretKey = NULL_SECRET_KEY;
 
     id = insertTransaction(std::move(transaction));
 

--- a/src/WalletLegacy/WalletUserTransactionsCache.cpp
+++ b/src/WalletLegacy/WalletUserTransactionsCache.cpp
@@ -237,6 +237,7 @@ TransactionId WalletUserTransactionsCache::addNewTransaction(uint64_t amount,
   transaction.blockHeight = WALLET_LEGACY_UNCONFIRMED_TRANSACTION_HEIGHT;
   transaction.state = WalletLegacyTransactionState::Sending;
   transaction.unlockTime = unlockTime;
+  transaction.secretKey = NULL_SECRET_KEY;
 
   for (const TransactionMessage& message : messages) {
     transaction.messages.push_back(message.message);
@@ -246,11 +247,12 @@ TransactionId WalletUserTransactionsCache::addNewTransaction(uint64_t amount,
 }
 
 void WalletUserTransactionsCache::updateTransaction(
-  TransactionId transactionId, const CryptoNote::Transaction& tx, uint64_t amount, const std::vector<TransactionOutputInformation>& usedOutputs) {
+  TransactionId transactionId, const CryptoNote::Transaction& tx, uint64_t amount, const std::vector<TransactionOutputInformation>& usedOutputs, Crypto::SecretKey& tx_key) {
   // update extra field from created transaction
   auto& txInfo = m_transactions.at(transactionId);
   txInfo.extra.assign(tx.extra.begin(), tx.extra.end());
-  m_unconfirmedTransactions.add(tx, transactionId, amount, usedOutputs);
+  txInfo.secretKey = tx_key;
+  m_unconfirmedTransactions.add(tx, transactionId, amount, usedOutputs, tx_key);
 }
 
 void WalletUserTransactionsCache::updateTransactionSendingState(TransactionId transactionId, std::error_code ec) {
@@ -303,6 +305,7 @@ std::deque<std::unique_ptr<WalletLegacyEvent>> WalletUserTransactionsCache::onTr
     transaction.state = WalletLegacyTransactionState::Active;
     transaction.unlockTime = txInfo.unlockTime;
     transaction.messages = txInfo.messages;
+    transaction.secretKey = txInfo.secretKey;
 
     id = insertTransaction(std::move(transaction));
 

--- a/src/WalletLegacy/WalletUserTransactionsCache.h
+++ b/src/WalletLegacy/WalletUserTransactionsCache.h
@@ -66,7 +66,8 @@ public:
   void updateTransaction(TransactionId transactionId,
                          const CryptoNote::Transaction& tx,
                          uint64_t amount,
-                         const std::vector<TransactionOutputInformation>& usedOutputs);
+                         const std::vector<TransactionOutputInformation>& usedOutputs,
+                         Crypto::SecretKey& tx_key);
   void updateTransactionSendingState(TransactionId transactionId, std::error_code ec);
 
   void addCreatedDeposit(DepositId id, uint64_t totalAmount);
@@ -88,6 +89,7 @@ public:
   WalletLegacyTransaction& getTransaction(TransactionId transactionId);
   bool getTransfer(TransferId transferId, WalletLegacyTransfer& transfer) const;
   WalletLegacyTransfer& getTransfer(TransferId transferId);
+  TransactionId findTransactionByHash(const Crypto::Hash& hash);
   bool getDeposit(DepositId depositId, Deposit& deposit) const;
   Deposit& getDeposit(DepositId depositId);
 
@@ -100,7 +102,6 @@ public:
   bool getDepositInTransactionInfo(DepositId depositId, Crypto::Hash& transactionHash, uint32_t& outputInTransaction);
 
   std::vector<Payments> getTransactionsByPaymentIds(const std::vector<PaymentId>& paymentIds) const;
-  TransactionId findTransactionByHash(const Crypto::Hash& hash);
 private:
 
 

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,2 +1,2 @@
-#define PROJECT_VERSION "1.0.1"
+#define PROJECT_VERSION "1.0.2"
 #define PROJECT_VERSION_BUILD_NO "Mainnet Release"


### PR DESCRIPTION
### v1.0.2 updates
- Get Transactions by Payment ID in RPC
- Update Readme
- Allow a user to check the transaction details of a sent transaction using a secret key provided
- Stop forcing 4 mixin!
- Check TX key can be done in `cache-wallet`
- Cleanup some warnings and remove dead code

#### To-Do
- Add API documentation about `check_tx_key` command

### Features
This allows one to check the amount of **$CXCHE** sent to a particular address in a particular transaction, given that transaction's secret `tx_key`